### PR TITLE
refactor: improve configuration names, docs and coding styles

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,0 @@
-{
-	// See http://go.microsoft.com/fwlink/?LinkId=827846
-	// for the documentation about the extensions.json format
-	"recommendations": [
-		"eg2.tslint"
-	]
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,22 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [1.2.5] - 2021-06-24
+
+### Changed
+
+- Reformatted files for easier readability (`Prettier` extension)
+- Formalized [README.md](README.md) contents
+- Changed property names (should not have spaces in them and was not descriptive to current extension)
+
+### Fixed
+
+- Some bug in VSCode `bin` installation when using yarn
+  - To fix, change stable releases link from `https://vscode-update.azurewebsites.net/api/releases/stable` to `https://update.code.visualstudio.com/api/releases/stable`
+
 ## [1.2.4] - 2020-09-11
 
-- Remove the introduction (temporarily) for `indent` character usage in Readme since it is buggy (see [#13](https://github.com/aprilandjan/vscode-ascii-tree-generator/issues/13)).
+- Remove the introduction (temporarily) for `indent` character usage in [README.md](README.md) since it is buggy (see [#13](https://github.com/aprilandjan/vscode-ascii-tree-generator/issues/13)).
 
 ## [1.2.3] - 2020-04-29
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,28 @@
-# [vscode ascii tree generator](https://marketplace.visualstudio.com/items?itemName=aprilandjan.ascii-tree-generator)
+# [VSCode ASCII Tree Generator](https://marketplace.visualstudio.com/items?itemName=aprilandjan.ascii-tree-generator)
 
 [![Build Status](https://dev.azure.com/merlinye/ascii-tree-generator/_apis/build/status/aprilandjan.ascii-tree-generator?branchName=master)](https://dev.azure.com/merlinye/ascii-tree-generator/_build/latest?definitionId=1?branchName=master)
 [![Download Count](https://img.shields.io/visual-studio-marketplace/d/aprilandjan.ascii-tree-generator)](https://marketplace.visualstudio.com/items?itemName=aprilandjan.ascii-tree-generator)
 [![Download Count](https://img.shields.io/visual-studio-marketplace/i/aprilandjan.ascii-tree-generator)](https://marketplace.visualstudio.com/items?itemName=aprilandjan.ascii-tree-generator)
 
-A vscode extension to generate ascii tree of directories or format selected text to tree string.
+Generate ASCII tree of directories or format selected text into its corresponding "tree string" representation.
 
 ## Usage
 
-This extension provides convenient way to generate ascii tree string for directory in workspace explorer. Besides, you can select text in editor and format it to tree string easily.
+Generate ASCII "tree strings" for any directory in the workspace explorer. Aside from that, you can also select pre-formatted text in the explorer and format it to its corresponding "tree string" easily.
 
-### Format Text to Tree String
+### Format Selected Text to Tree String
 
-Write simple tree lines in certain syntax (see example below), select these lines, right-click on text and click `Format Text to Tree String` menu:
+Using the `#` (octothorpe/hash) character, you can specify the depth of the current element. After writing a few lines (see example below), select the targetted pre-formatted lines, right-click on the highlighted text selection, and click `Format to Tree String` menu option. This will replace the selected, pre-formatted text, into its corresponding "tree string" representation.
 
 ![Format Text to Tree String](./images/text.gif)
 
-The lines started with `hash(#)` characters can be used to represent the depth of the directory tree. For example:
+For clarity, each line of your target tree structure should begin with at least a single `#` (octothorpe/hash) character. At most, each line can only have one more additional `#` than any line above it. This will ensure proper formatting. By placing multiple `#` symbols, it is possible to designate the depth of a certain element.
 
-```
+#### Demonstration
+
+**Pre-Formatted Tree String**
+
+```txt
 # public
 # dist
 ## index.d.ts
@@ -27,9 +31,9 @@ The lines started with `hash(#)` characters can be used to represent the depth o
 ## index.ts
 ```
 
-They should be formatted to:
+**Formatted Tree String**
 
-```
+```txt
 .
 ├── public
 ├── dist
@@ -39,42 +43,51 @@ They should be formatted to:
   └── index.ts
 ```
 
-**Note**: In most cases, you can just simply undo the formatting operation using the vscode editor `undo` ability. The default shortcut is <kbd>cmd</kbd>+<kbd>Z</kbd>. Besides,
-You can open the VS Code `Command Palette` and execute `Revert Tree String to Text` to revert tree string back to hash-style texts, in case that your undo history is lost for some reason.
+#### Addendum
+
+In cases where you would like to undo the formatting operation, simply use VSCode's editor `undo` option (`Edit`&rarr;`Undo`). You can optionally use the keybindings for undo as well (<kbd>⌘</kbd>+<kbd>Z</kbd> on Mac or <kbd>CTRL</kbd>+<kbd>Z</kbd> on Windows). However, this option will fail in cases where the `undo` operation is invalid (e.g. text inside downloaded materials).
+
+In all cases, you can revert formatting tree strings back to their preformatted versions by selecting the formatted tree string, heading to the VSCode Command Pallete (<kbd>⌘</kbd>+<kbd>SHIFT</kbd>+<kbd>P</kbd> on Mac or <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>P</kbd> on Windows), and executing `Revert Tree String to Text`. As long as the matching lines up, this should provide back your intended pre-formatted tree string.
 
 ### Generate Tree String for Directory
 
-Right-click on `Explorer` directories, click `Generate Tree String for Directory` menu:
+In addition to being able to format pre-formatted tree strings, you may also generate tree strings for directories inside your current workspace (directories appearing in `Explorer` tab). To do so, right-click on any directory within the `Explorer` tab and select the `Generate Tree String for Directory` menu option. An example is shown below.
 
 ![Generate Tree String for Directory](./images/directory.gif)
 
-**Note**: This process of walking through files is asynchronous. So if you include some heavy-nested folders, `node_modules` for example, the result will be slow to show.
+#### Addendum
+
+The walking process through files is performed asynchronously. Therefore, selecting heavily-nested folders (e.g. `node_modules`) will directly affect performance speed.
 
 ## Configuration
 
-Each character of the tree can be defined by its ASCII code (or UTF character code in general). The theoretical range for character codes is 0 to 65535. However, not every code will lead to a printable character and may cause formatting problems.
+Each tree string character can be defined by its ASCII code representation (UTF character code, more generally). As such, the theorectical range for character codes is `0` to `65535` (two bytes). However, and important to note, is that not every character code is printable and/or may cause formatting issues.
+
 The available parameters are:
 
-| Name | Default Char Code | Default  Character   | Description     |
-| -----------------------------| ---- | --------  | --------------- |
-| asciiTreeGenerator.blankElement  | 32   | '&#32;'   | For blanks / spaces |
-| asciiTreeGenerator.childElement  | 9500 | '&#9500;' | For intermediate child elements |
-| asciiTreeGenerator.dashElement   | 9472 | '&#9472;' | For horizontal dashes |
-| asciiTreeGenerator.lastElement   | 9492 | '&#9492;' | For the last element of a path |
-| asciiTreeGenerator.parentElement | 9474 | '&#9474;' | For vertical parent elements |
-| asciiTreeGenerator.rootElement   | 46   | '&#46;'   | For the root element (on top) |
-
+| Property (Setting) Name            | Default Character Code | Default Character  | Description                  |
+| ---------------------------------- | :--------------------: | :----------------: | ---------------------------- |
+| `asciiTreeGenerator.rootElement`   |          `46`          |  <kbd>&#46;</kbd>  | For root elements            |
+| `asciiTreeGenerator.parentElement` |         `9474`         | <kbd>&#9474;</kbd> | For vertical parent elements |
+| `asciiTreeGenerator.childElement`  |         `9500`         | <kbd>&#9500;</kbd> | For child elements           |
+| `asciiTreeGenerator.lastElement`   |         `9492`         | <kbd>&#9492;</kbd> | For last elements of paths   |
+| `asciiTreeGenerator.dashElement`   |         `9472`         | <kbd>&#9472;</kbd> | For horizontal dash elements |
+| `asciiTreeGenerator.blankElement`  |          `32`          |  <kbd>&#32;</kbd>  | For blank / space elements   |
 
 ### Sample Configurations
 
-| Configuration     | Blank      | Child          | Dash           | Last           | Parent         | Root           |
-| ----------------- | ---------- | -------------- | -------------- | -------------- | -------------- | -------------- |
-| Default           | 32 (&#32;) | 9500 (&#9500;) | 9472 (&#9472;) | 9492 (&#9492;) | 9474 (&#9474;) | 46 (&#46;)     |
-| Double Line       | 32 (&#32;) | 9568 (&#9568;) | 9552 (&#9552;) | 9562 (&#9562;) | 9553 (&#9553;) | 9559 (&#9559;) |
-| Classic           | 32 (&#32;) | 124 (&#124;)   | 45 (&#45;)     | 43 (&#43;)     | 124 (&#124;)   | 43 (&#43;)     |
-| Classic Rounded   | 32 (&#32;) | 124 (&#124;)   | 45 (&#45;)     | 96 (&#96;)     | 124 (&#124;)   | 46 (&#43;)     |
-| Exclamation Marks | 32 (&#32;) | 35 (&#35;)     | 61 (&#61;)     | 42 (&#42;)     | 33 (&#33;)     | 35 (&#35;)     |
+Commonly used configurations that you can manually enable by entering the values for each of the aforementioned property names above (perfom these changes inside a `settings.json` file).
 
-## Issues & Contribution
+|   Configuration   |           Root            |          Parent           |           Child           |           Last            |           Dash            |         Blank         |
+| :---------------: | :-----------------------: | :-----------------------: | :-----------------------: | :-----------------------: | :-----------------------: | :-------------------: |
+|      Default      |   `46` <kbd>&#46;</kbd>   | `9474` <kbd>&#9474;</kbd> | `9500` <kbd>&#9500;</kbd> | `9492` <kbd>&#9492;</kbd> | `9472` <kbd>&#9472;</kbd> | `32` <kbd>&#32;</kbd> |
+|    Double Line    | `9559` <kbd>&#9559;</kbd> | `9553` <kbd>&#9553;</kbd> | `9568` <kbd>&#9568;</kbd> | `9562` <kbd>&#9562;</kbd> | `9552` <kbd>&#9552;</kbd> | `32` <kbd>&#32;</kbd> |
+|      Classic      |   `43` <kbd>&#43;</kbd>   |  `124` <kbd>&#124;</kbd>  |  `124` <kbd>&#124;</kbd>  |   `43` <kbd>&#43;</kbd>   |   `45` <kbd>&#45;</kbd>   | `32` <kbd>&#32;</kbd> |
+|  Classic Rounded  |   `43` <kbd>&#43;</kbd>   |  `124` <kbd>&#124;</kbd>  |  `124` <kbd>&#124;</kbd>  |   `96` <kbd>&#96;</kbd>   |   `45` <kbd>&#45;</kbd>   | `32` <kbd>&#32;</kbd> |
+| Exclamation Marks |   `35` <kbd>&#35;</kbd>   |   `33` <kbd>&#33;</kbd>   |   `35` <kbd>&#35;</kbd>   |   `42` <kbd>&#42;</kbd>   |   `61` <kbd>&#61;</kbd>   | `32` <kbd>&#32;</kbd> |
 
-Please feel free to submit issues if you have any questions. Contribution is also welcomed :)
+## Issues and  Contribution
+
+Please feel free to submit any issues or bugs you find with the extension. More generally, please reach out if you have any questions on how to use the extension.
+
+Finally, contribution or ideas are humbly welcomed so please check us out on GitHub :) !

--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ The available parameters are:
 
 | Name | Default Char Code | Default  Character   | Description     |
 | -----------------------------| ---- | --------  | --------------- |
-| Blank element character code  | 32   | '&#32;'   | For blanks / spaces |
-| Child element character code  | 9500 | '&#9500;' | For intermediate child elements |
-| Dash element character code   | 9472 | '&#9472;' | For horizontal dashes |
-| Last element character code   | 9492 | '&#9492;' | For the last element of a path |
-| Parent element character code | 9474 | '&#9474;' | For vertical parent elements |
-| Root element character code   | 46   | '&#46;'   | For the root element (on top) |
+| asciiTreeGenerator.blankElement  | 32   | '&#32;'   | For blanks / spaces |
+| asciiTreeGenerator.childElement  | 9500 | '&#9500;' | For intermediate child elements |
+| asciiTreeGenerator.dashElement   | 9472 | '&#9472;' | For horizontal dashes |
+| asciiTreeGenerator.lastElement   | 9492 | '&#9492;' | For the last element of a path |
+| asciiTreeGenerator.parentElement | 9474 | '&#9474;' | For vertical parent elements |
+| asciiTreeGenerator.rootElement   | 46   | '&#46;'   | For the root element (on top) |
 
 
 ### Sample Configurations

--- a/package.json
+++ b/package.json
@@ -1,132 +1,132 @@
 {
-	"name": "ascii-tree-generator",
-	"displayName": "Ascii Tree Generator",
-	"description": "A vscode extension to generate ascii tree of directories or formatting selected text to tree string.",
-	"version": "1.2.4",
-	"engines": {
-		"vscode": "^1.30.0"
-	},
-	"categories": [
-		"Formatters",
-		"Other"
-	],
-	"publisher": "aprilandjan",
-	"license": "SEE LICENSE IN LICENSE",
-	"icon": "images/icon.png",
-	"galleryBanner": {
-		"color": "#135200",
-		"theme": "dark"
-	},
-	"author": "aprilandjan",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/aprilandjan/vscode-ascii-tree-generator"
-	},
-	"activationEvents": [
-		"onCommand:extension.asciiTreeGenerator",
-		"onCommand:extension.asciiTreeGeneratorFromDirectory",
-		"onCommand:extension.asciiTreeGeneratorFromText",
-		"onCommand:extension.asciiTreeGeneratorRevertToText"
-	],
-	"main": "./out/extension.js",
-	"contributes": {
-		"configuration": [
-			{
-				"title": "Ascii Tree Generator Configuration",
-				"properties": {
-					"Root element character code": {
-						"type": "integer",
-						"default": 46,
-						"description": "For the root element (0-65535; Default: 46 '.')"
-					},
-					"Child element character code": {
-						"type": "integer",
-						"default": 9500,
-						"description": "For child elements (0-65535; Default: 9500 '&#9500;')"
-					},
-					"Last element character code": {
-						"type": "integer",
-						"default": 9492,
-						"description": "For the last element of a path (0-65535; Default: 9492 '&#9492;')"
-					},
-					"Parent element character code": {
-						"type": "integer",
-						"default": 9474,
-						"description": "For vertical parent elements (0-65535; Default: 9474 '&#9474;')"
-					},
-					"Dash element character code": {
-						"type": "integer",
-						"default": 9472,
-						"description": "For horizontal dashes (0-65535; Default: 9472 '&#9472;')"
-					},
-					"Blank element character code": {
-						"type": "integer",
-						"default": 32,
-						"description": "For blanks / spaces (0-65535; Default: 32 ' ')"
-					}
-				}
-			}
-		],
-		"commands": [
-			{
-				"command": "extension.asciiTreeGenerator",
-				"title": "Generate Tree",
-				"category": "Ascii Tree Generator"
-			},
-			{
-				"command": "extension.asciiTreeGeneratorFromDirectory",
-				"title": "Generate Tree String",
-				"category": "Ascii Tree Generator"
-			},
-			{
-				"command": "extension.asciiTreeGeneratorFromText",
-				"title": "Format Text to Tree String",
-				"category": "Ascii Tree Generator"
-			},
-			{
-				"command": "extension.asciiTreeGeneratorRevertToText",
-				"title": "Revert Tree String to Text",
-				"category": "Ascii Tree Generator"
-			}
-		],
-		"menus": {
-			"commandPalette": [
-				{
-					"command": "extension.asciiTreeGenerator"
-				}
-			],
-			"explorer/context": [
-				{
-					"command": "extension.asciiTreeGeneratorFromDirectory",
-					"group": "asciiTreeGenerator@1",
-					"when": "explorerResourceIsFolder"
-				}
-			],
-			"editor/context": [
-				{
-					"command": "extension.asciiTreeGeneratorFromText",
-					"group": "asciiTreeGenerator@1",
-					"when": "editorHasSelection"
-				}
-			]
-		}
-	},
-	"scripts": {
-		"vscode:prepublish": "yarn run compile",
-		"compile": "tsc -p ./",
-		"watch": "tsc -watch -p ./",
-		"postinstall": "node ./node_modules/vscode/bin/install",
-		"test": "yarn run compile && node ./node_modules/vscode/bin/test"
-	},
-	"devDependencies": {
-		"@types/glob": "^7.1.1",
-		"@types/mocha": "^2.2.42",
-		"@types/node": "^8.10.25",
-		"tslint": "^5.20.0",
-		"typescript": "^3.1.4",
-		"vscode": "^1.1.36"
-	},
-	"dependencies": {
-		"glob": "^7.1.3"
-	}
+    "name": "ascii-tree-generator",
+    "displayName": "Ascii Tree Generator",
+    "description": "A vscode extension to generate ascii tree of directories or formatting selected text to tree string.",
+    "version": "1.2.4",
+    "engines": {
+        "vscode": "^1.30.0"
+    },
+    "categories": [
+        "Formatters",
+        "Other"
+    ],
+    "publisher": "aprilandjan",
+    "license": "SEE LICENSE IN LICENSE",
+    "icon": "images/icon.png",
+    "galleryBanner": {
+        "color": "#135200",
+        "theme": "dark"
+    },
+    "author": "aprilandjan",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/aprilandjan/vscode-ascii-tree-generator"
+    },
+    "activationEvents": [
+        "onCommand:extension.asciiTreeGenerator",
+        "onCommand:extension.asciiTreeGeneratorFromDirectory",
+        "onCommand:extension.asciiTreeGeneratorFromText",
+        "onCommand:extension.asciiTreeGeneratorRevertToText"
+    ],
+    "main": "./out/extension.js",
+    "contributes": {
+        "configuration": [
+            {
+                "title": "Ascii Tree Generator Configuration",
+                "properties": {
+                    "Root element character code": {
+                        "type": "integer",
+                        "default": 46,
+                        "description": "For the root element (0-65535; Default: 46 '.')"
+                    },
+                    "Child element character code": {
+                        "type": "integer",
+                        "default": 9500,
+                        "description": "For child elements (0-65535; Default: 9500 '&#9500;')"
+                    },
+                    "Last element character code": {
+                        "type": "integer",
+                        "default": 9492,
+                        "description": "For the last element of a path (0-65535; Default: 9492 '&#9492;')"
+                    },
+                    "Parent element character code": {
+                        "type": "integer",
+                        "default": 9474,
+                        "description": "For vertical parent elements (0-65535; Default: 9474 '&#9474;')"
+                    },
+                    "Dash element character code": {
+                        "type": "integer",
+                        "default": 9472,
+                        "description": "For horizontal dashes (0-65535; Default: 9472 '&#9472;')"
+                    },
+                    "Blank element character code": {
+                        "type": "integer",
+                        "default": 32,
+                        "description": "For blanks / spaces (0-65535; Default: 32 ' ')"
+                    }
+                }
+            }
+        ],
+        "commands": [
+            {
+                "command": "extension.asciiTreeGenerator",
+                "title": "Generate Tree",
+                "category": "Ascii Tree Generator"
+            },
+            {
+                "command": "extension.asciiTreeGeneratorFromDirectory",
+                "title": "Generate Tree String",
+                "category": "Ascii Tree Generator"
+            },
+            {
+                "command": "extension.asciiTreeGeneratorFromText",
+                "title": "Format Text to Tree String",
+                "category": "Ascii Tree Generator"
+            },
+            {
+                "command": "extension.asciiTreeGeneratorRevertToText",
+                "title": "Revert Tree String to Text",
+                "category": "Ascii Tree Generator"
+            }
+        ],
+        "menus": {
+            "commandPalette": [
+                {
+                    "command": "extension.asciiTreeGenerator"
+                }
+            ],
+            "explorer/context": [
+                {
+                    "command": "extension.asciiTreeGeneratorFromDirectory",
+                    "group": "asciiTreeGenerator@1",
+                    "when": "explorerResourceIsFolder"
+                }
+            ],
+            "editor/context": [
+                {
+                    "command": "extension.asciiTreeGeneratorFromText",
+                    "group": "asciiTreeGenerator@1",
+                    "when": "editorHasSelection"
+                }
+            ]
+        }
+    },
+    "scripts": {
+        "vscode:prepublish": "yarn run compile",
+        "compile": "tsc -p ./",
+        "watch": "tsc -watch -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "test": "yarn run compile && node ./node_modules/vscode/bin/test"
+    },
+    "devDependencies": {
+        "@types/glob": "^7.1.1",
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^8.10.25",
+        "tslint": "^5.20.0",
+        "typescript": "^3.1.4",
+        "vscode": "^1.1.36"
+    },
+    "dependencies": {
+        "glob": "^7.1.3"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -34,35 +34,35 @@
             {
                 "title": "Ascii Tree Generator Configuration",
                 "properties": {
-                    "Root element character code": {
+                    "asciiTreeGenerator.rootElement": {
                         "type": "integer",
                         "default": 46,
-                        "description": "For the root element (0-65535; Default: 46 '.')"
+                        "description": "For root elements (0-65535; Default: 46 '.')"
                     },
-                    "Child element character code": {
+                    "asciiTreeGenerator.childElement": {
                         "type": "integer",
                         "default": 9500,
                         "description": "For child elements (0-65535; Default: 9500 '&#9500;')"
                     },
-                    "Last element character code": {
+                    "asciiTreeGenerator.lastElement": {
                         "type": "integer",
                         "default": 9492,
-                        "description": "For the last element of a path (0-65535; Default: 9492 '&#9492;')"
+                        "description": "For last elements of paths (0-65535; Default: 9492 '&#9492;')"
                     },
-                    "Parent element character code": {
+                    "asciiTreeGenerator.parentElement": {
                         "type": "integer",
                         "default": 9474,
                         "description": "For vertical parent elements (0-65535; Default: 9474 '&#9474;')"
                     },
-                    "Dash element character code": {
+                    "asciiTreeGenerator.dashElement": {
                         "type": "integer",
                         "default": 9472,
-                        "description": "For horizontal dashes (0-65535; Default: 9472 '&#9472;')"
+                        "description": "For horizontal dash elements (0-65535; Default: 9472 '&#9472;')"
                     },
-                    "Blank element character code": {
+                    "asciiTreeGenerator.blankElement": {
                         "type": "integer",
                         "default": 32,
-                        "description": "For blanks / spaces (0-65535; Default: 32 ' ')"
+                        "description": "For blank / space elements (0-65535; Default: 32 ' ')"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "Other"
     ],
     "publisher": "aprilandjan",
-    "license": "SEE LICENSE IN LICENSE",
+    "license": "MIT",
     "icon": "images/icon.png",
     "galleryBanner": {
         "color": "#135200",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A vscode extension to generate ascii tree of directories or formatting selected text to tree string.",
     "version": "1.2.4",
     "engines": {
-        "vscode": "^1.30.0"
+        "vscode": "^1.50.0"
     },
     "categories": [
         "Formatters",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
                         "default": 46,
                         "description": "For root elements (0-65535; Default: 46 '.')"
                     },
+                    "asciiTreeGenerator.parentElement": {
+                        "type": "integer",
+                        "default": 9474,
+                        "description": "For vertical parent elements (0-65535; Default: 9474 '&#9474;')"
+                    },
                     "asciiTreeGenerator.childElement": {
                         "type": "integer",
                         "default": 9500,
@@ -48,11 +53,6 @@
                         "type": "integer",
                         "default": 9492,
                         "description": "For last elements of paths (0-65535; Default: 9492 '&#9492;')"
-                    },
-                    "asciiTreeGenerator.parentElement": {
-                        "type": "integer",
-                        "default": 9474,
-                        "description": "For vertical parent elements (0-65535; Default: 9474 '&#9474;')"
                     },
                     "asciiTreeGenerator.dashElement": {
                         "type": "integer",

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,22 +6,22 @@ export function getConfig(): IVsCodeConfig {
         ignore: ["node_modules"],
         rootCharCode: vscode.workspace
             .getConfiguration()
-            .get<number>("Root element character code"),
-        childCharCode: vscode.workspace
-            .getConfiguration()
-            .get<number>("Child element character code"),
-        lastCharCode: vscode.workspace
-            .getConfiguration()
-            .get<number>("Last element character code"),
+            .get<number>("asciiTreeGenerator.rootElement"),
         parentCharCode: vscode.workspace
             .getConfiguration()
-            .get<number>("Parent element character code"),
+            .get<number>("asciiTreeGenerator.parentElement"),
+        childCharCode: vscode.workspace
+            .getConfiguration()
+            .get<number>("asciiTreeGenerator.childElement"),
+        lastCharCode: vscode.workspace
+            .getConfiguration()
+            .get<number>("asciiTreeGenerator.lastElement"),
         dashCharCode: vscode.workspace
             .getConfiguration()
-            .get<number>("Dash element character code"),
+            .get<number>("asciiTreeGenerator.dashElement"),
         blankCharCode: vscode.workspace
             .getConfiguration()
-            .get<number>("Blank element character code"),
+            .get<number>("asciiTreeGenerator.blankElement"),
     };
     return config;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,18 +1,27 @@
-import * as vscode from 'vscode';
-import { IVsCodeConfig } from './lib/interface';
+import * as vscode from "vscode";
+import { IVsCodeConfig } from "./lib/interface";
 
 export function getConfig(): IVsCodeConfig {
-  let config: IVsCodeConfig = {
-    ignore: [
-      'node_modules'
-    ],
-    rootCharCode: vscode.workspace.getConfiguration().get<number>("Root element character code"),
-    childCharCode: vscode.workspace.getConfiguration().get<number>("Child element character code"),
-    lastCharCode: vscode.workspace.getConfiguration().get<number>("Last element character code"),
-    parentCharCode: vscode.workspace.getConfiguration().get<number>("Parent element character code"),
-    dashCharCode: vscode.workspace.getConfiguration().get<number>("Dash element character code"),
-    blankCharCode: vscode.workspace.getConfiguration().get<number>("Blank element character code")
-  };
-  return config;
+    let config: IVsCodeConfig = {
+        ignore: ["node_modules"],
+        rootCharCode: vscode.workspace
+            .getConfiguration()
+            .get<number>("Root element character code"),
+        childCharCode: vscode.workspace
+            .getConfiguration()
+            .get<number>("Child element character code"),
+        lastCharCode: vscode.workspace
+            .getConfiguration()
+            .get<number>("Last element character code"),
+        parentCharCode: vscode.workspace
+            .getConfiguration()
+            .get<number>("Parent element character code"),
+        dashCharCode: vscode.workspace
+            .getConfiguration()
+            .get<number>("Dash element character code"),
+        blankCharCode: vscode.workspace
+            .getConfiguration()
+            .get<number>("Blank element character code"),
+    };
+    return config;
 }
-

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,120 +1,148 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import * as vscode from 'vscode';
-import * as path from 'path';
+import * as vscode from "vscode";
+import * as path from "path";
 // import * as fs from 'fs';
 
-import { formatFileTreeItemsFromDirectory } from './lib/directory';
-import { generate } from './lib/generator';
-import { getUserEOL, createWebview, revertTreeString } from './utils';
-import { formatFileTreeItemsFromText } from './lib/text';
+import { formatFileTreeItemsFromDirectory } from "./lib/directory";
+import { generate } from "./lib/generator";
+import { getUserEOL, createWebview, revertTreeString } from "./utils";
+import { formatFileTreeItemsFromText } from "./lib/text";
 
 export function activate(context: vscode.ExtensionContext) {
-	function registerCommand(cmd: string, callback: any) {
-		context.subscriptions.push(
-			vscode.commands.registerCommand(cmd, callback),
-		);
-	}
+    function registerCommand(cmd: string, callback: any) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand(cmd, callback)
+        );
+    }
 
-	registerCommand('extension.asciiTreeGenerator', async (resource: any) => {
-		const workspaces = vscode.workspace.workspaceFolders;
-		const rootWorkspace: vscode.WorkspaceFolder | undefined = workspaces ? workspaces[0] : undefined;
-		if (!rootWorkspace) {
-			vscode.window.showWarningMessage('Ascii Tree Generator need to be used with valid workspace folder!');
-			return;
-		}
-		//	if no selected resource found, then try to get workspace root path
-		const target: vscode.Uri = resource || rootWorkspace.uri;
-		const root = path.relative(rootWorkspace.uri.fsPath, target.fsPath) || '.';
+    registerCommand("extension.asciiTreeGenerator", async (resource: any) => {
+        const workspaces = vscode.workspace.workspaceFolders;
+        const rootWorkspace: vscode.WorkspaceFolder | undefined = workspaces
+            ? workspaces[0]
+            : undefined;
+        if (!rootWorkspace) {
+            vscode.window.showWarningMessage(
+                "Ascii Tree Generator need to be used with valid workspace folder!"
+            );
+            return;
+        }
+        //	if no selected resource found, then try to get workspace root path
+        const target: vscode.Uri = resource || rootWorkspace.uri;
+        const root =
+            path.relative(rootWorkspace.uri.fsPath, target.fsPath) || ".";
 
-		// Todo: read plugin configuration
-		const items = await formatFileTreeItemsFromDirectory(target!.fsPath, {
-			maxDepth: Number.MAX_VALUE,
-			sort: true,
-			ignore: [],
-		});
-		const text = generate(items, {
-			eol: getUserEOL(),
-			root,
-		});
+        // Todo: read plugin configuration
+        const items = await formatFileTreeItemsFromDirectory(target!.fsPath, {
+            maxDepth: Number.MAX_VALUE,
+            sort: true,
+            ignore: [],
+        });
+        const text = generate(items, {
+            eol: getUserEOL(),
+            root,
+        });
 
-		createWebview(context, text);
-	});
+        createWebview(context, text);
+    });
 
-	//	create ascii tree from directory
-	registerCommand('extension.asciiTreeGeneratorFromDirectory', async (resource: vscode.Uri | undefined) => {
-		const workspaces = vscode.workspace.workspaceFolders;
-		const rootWorkspace: vscode.WorkspaceFolder | undefined = workspaces ? workspaces[0] : undefined;
-		if (!rootWorkspace) {
-			vscode.window.showWarningMessage('Ascii Tree Generator need to be used with valid workspace folder!');
-			return;
-		}
-		//	if no selected resource found, then try to get workspace root path
-		const target: vscode.Uri = resource || rootWorkspace.uri;
-		const root = path.relative(rootWorkspace.uri.fsPath, target.fsPath) || '.';
+    //	create ascii tree from directory
+    registerCommand(
+        "extension.asciiTreeGeneratorFromDirectory",
+        async (resource: vscode.Uri | undefined) => {
+            const workspaces = vscode.workspace.workspaceFolders;
+            const rootWorkspace: vscode.WorkspaceFolder | undefined = workspaces
+                ? workspaces[0]
+                : undefined;
+            if (!rootWorkspace) {
+                vscode.window.showWarningMessage(
+                    "Ascii Tree Generator need to be used with valid workspace folder!"
+                );
+                return;
+            }
+            //	if no selected resource found, then try to get workspace root path
+            const target: vscode.Uri = resource || rootWorkspace.uri;
+            const root =
+                path.relative(rootWorkspace.uri.fsPath, target.fsPath) || ".";
 
-		// Todo: read plugin configuration
-		const items = await formatFileTreeItemsFromDirectory(target!.fsPath, {
-			maxDepth: Number.MAX_VALUE,
-			sort: true,
-			ignore: [],
-		});
-		const text = generate(items, {
-			eol: getUserEOL(),
-			root,
-		});
-		createWebview(context, text);
-	});
+            // Todo: read plugin configuration
+            const items = await formatFileTreeItemsFromDirectory(
+                target!.fsPath,
+                {
+                    maxDepth: Number.MAX_VALUE,
+                    sort: true,
+                    ignore: [],
+                }
+            );
+            const text = generate(items, {
+                eol: getUserEOL(),
+                root,
+            });
+            createWebview(context, text);
+        }
+    );
 
-	registerCommand('extension.asciiTreeGeneratorFromText', async (resource: any) => {
-		const editor = vscode.window.activeTextEditor;
-		if (!editor || editor.selection.isEmpty) {
-			vscode.window.showWarningMessage('No text selected. Please select text in editor before generating Tree String!');
-			return;
-		}
-		//	find and select lines where current selection range locates
-		const start = editor.selection.start.line;
-		const end = editor.selection.end.line;
-		const endLineSize = editor.document.lineAt(end).text.length;
+    registerCommand(
+        "extension.asciiTreeGeneratorFromText",
+        async (resource: any) => {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor || editor.selection.isEmpty) {
+                vscode.window.showWarningMessage(
+                    "No text selected. Please select text in editor before generating Tree String!"
+                );
+                return;
+            }
+            //	find and select lines where current selection range locates
+            const start = editor.selection.start.line;
+            const end = editor.selection.end.line;
+            const endLineSize = editor.document.lineAt(end).text.length;
 
-		const range = editor.document.validateRange(new vscode.Range(
-			new vscode.Position(start, 0),
-			new vscode.Position(end, endLineSize),
-		));
-		editor.selection = new vscode.Selection(range.start, range.end);
+            const range = editor.document.validateRange(
+                new vscode.Range(
+                    new vscode.Position(start, 0),
+                    new vscode.Position(end, endLineSize)
+                )
+            );
+            editor.selection = new vscode.Selection(range.start, range.end);
 
-		//	generate text and replace...
-		const rawText = editor.document.getText(range);
-		const items = formatFileTreeItemsFromText(rawText);
-		const text = generate(items, {
-			eol: editor.document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n',
-			// Todo: read plugin configurations
-		});
-		editor.edit((edit) => {
-			edit.replace(editor.selection, text);
-		});
-	});
+            //	generate text and replace...
+            const rawText = editor.document.getText(range);
+            const items = formatFileTreeItemsFromText(rawText);
+            const text = generate(items, {
+                eol:
+                    editor.document.eol === vscode.EndOfLine.CRLF
+                        ? "\r\n"
+                        : "\n",
+                // Todo: read plugin configurations
+            });
+            editor.edit((edit) => {
+                edit.replace(editor.selection, text);
+            });
+        }
+    );
 
-	registerCommand('extension.asciiTreeGeneratorRevertToText', async () => {
-		const editor = vscode.window.activeTextEditor;
-		if (!editor) {
-			vscode.window.showWarningMessage('Please open the file you want to revert!');
-			return;
-		}
-		const text = editor.document.getText();
-		const reverted = revertTreeString(text);
-		const firstLine = editor.document.lineAt(0);
-		const lastLine = editor.document.lineAt(editor.document.lineCount - 1);
-		const range = new vscode.Range(
-			0,
-			firstLine.range.start.character,
-			editor.document.lineCount - 1,
-			lastLine.range.end.character,
-		);
-		editor.edit((edit) => {
-			edit.replace(range, reverted);
-		});
-	});
+    registerCommand("extension.asciiTreeGeneratorRevertToText", async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            vscode.window.showWarningMessage(
+                "Please open the file you want to revert!"
+            );
+            return;
+        }
+        const text = editor.document.getText();
+        const reverted = revertTreeString(text);
+        const firstLine = editor.document.lineAt(0);
+        const lastLine = editor.document.lineAt(editor.document.lineCount - 1);
+        const range = new vscode.Range(
+            0,
+            firstLine.range.start.character,
+            editor.document.lineCount - 1,
+            lastLine.range.end.character
+        );
+        editor.edit((edit) => {
+            edit.replace(range, reverted);
+        });
+    });
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ export function activate(context: vscode.ExtensionContext) {
             : undefined;
         if (!rootWorkspace) {
             vscode.window.showWarningMessage(
-                "Ascii Tree Generator need to be used with valid workspace folder!"
+                "ASCII Tree Generator need to be used with valid workspace folder!"
             );
             return;
         }
@@ -56,7 +56,7 @@ export function activate(context: vscode.ExtensionContext) {
                 : undefined;
             if (!rootWorkspace) {
                 vscode.window.showWarningMessage(
-                    "Ascii Tree Generator need to be used with valid workspace folder!"
+                    "ASCII Tree Generator need to be used with valid workspace folder!"
                 );
                 return;
             }
@@ -82,44 +82,38 @@ export function activate(context: vscode.ExtensionContext) {
         }
     );
 
-    registerCommand(
-        "extension.asciiTreeGeneratorFromText",
-        async (resource: any) => {
-            const editor = vscode.window.activeTextEditor;
-            if (!editor || editor.selection.isEmpty) {
-                vscode.window.showWarningMessage(
-                    "No text selected. Please select text in editor before generating Tree String!"
-                );
-                return;
-            }
-            //	find and select lines where current selection range locates
-            const start = editor.selection.start.line;
-            const end = editor.selection.end.line;
-            const endLineSize = editor.document.lineAt(end).text.length;
-
-            const range = editor.document.validateRange(
-                new vscode.Range(
-                    new vscode.Position(start, 0),
-                    new vscode.Position(end, endLineSize)
-                )
+    registerCommand("extension.asciiTreeGeneratorFromText", async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor || editor.selection.isEmpty) {
+            vscode.window.showWarningMessage(
+                "No text selected. Please select text in editor before generating tree string!"
             );
-            editor.selection = new vscode.Selection(range.start, range.end);
-
-            //	generate text and replace...
-            const rawText = editor.document.getText(range);
-            const items = formatFileTreeItemsFromText(rawText);
-            const text = generate(items, {
-                eol:
-                    editor.document.eol === vscode.EndOfLine.CRLF
-                        ? "\r\n"
-                        : "\n",
-                // Todo: read plugin configurations
-            });
-            editor.edit((edit) => {
-                edit.replace(editor.selection, text);
-            });
+            return;
         }
-    );
+        //	find and select lines where current selection range locates
+        const start = editor.selection.start.line;
+        const end = editor.selection.end.line;
+        const endLineSize = editor.document.lineAt(end).text.length;
+
+        const range = editor.document.validateRange(
+            new vscode.Range(
+                new vscode.Position(start, 0),
+                new vscode.Position(end, endLineSize)
+            )
+        );
+        editor.selection = new vscode.Selection(range.start, range.end);
+
+        //	generate text and replace...
+        const rawText = editor.document.getText(range);
+        const items = formatFileTreeItemsFromText(rawText);
+        const text = generate(items, {
+            eol: editor.document.eol === vscode.EndOfLine.CRLF ? "\r\n" : "\n",
+            // Todo: read plugin configurations
+        });
+        editor.edit((edit) => {
+            edit.replace(editor.selection, text);
+        });
+    });
 
     registerCommand("extension.asciiTreeGeneratorRevertToText", async () => {
         const editor = vscode.window.activeTextEditor;

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,36 +1,48 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import * as assert from 'assert';
-import { revertTreeString } from '../utils';
+import * as fs from "fs";
+import * as path from "path";
+import * as assert from "assert";
+import { revertTreeString } from "../utils";
 
 // Defines a Mocha test suite to group tests of similar kind together
-suite('Extension Tests', function () {
-  this.timeout(120000);
+suite("Extension Tests", function () {
+    this.timeout(120000);
 
-  // Defines a Mocha unit test
-  // test("Something 1", function() {
-  //     assert.equal(-1, [1, 2, 3].indexOf(5));
-  //     assert.equal(-1, [1, 2, 3].indexOf(0));
-  // });
-  test('revert tree string to text', function () {
-    const rootText = fs.readFileSync(path.join(__dirname, '../../fixtures/root.txt'), 'utf8');
-    const rootReverted = fs.readFileSync(path.join(__dirname, '../../fixtures/root-reverted.txt'), 'utf8');
-    const reverted = revertTreeString(rootText);
-    const a = reverted.trim().split('\n');
-    const b = rootReverted.trim().split('\n');
-    a.forEach((line, idx) => {
-      if (a[idx] !== b[idx]) {
-        console.log(a[idx], b[idx]);
-      }
+    // Defines a Mocha unit test
+    // test("Something 1", function() {
+    //     assert.equal(-1, [1, 2, 3].indexOf(5));
+    //     assert.equal(-1, [1, 2, 3].indexOf(0));
+    // });
+    test("revert tree string to text", function () {
+        const rootText = fs.readFileSync(
+            path.join(__dirname, "../../fixtures/root.txt"),
+            "utf8"
+        );
+        const rootReverted = fs.readFileSync(
+            path.join(__dirname, "../../fixtures/root-reverted.txt"),
+            "utf8"
+        );
+        const reverted = revertTreeString(rootText);
+        const a = reverted.trim().split("\n");
+        const b = rootReverted.trim().split("\n");
+        a.forEach((line, idx) => {
+            if (a[idx] !== b[idx]) {
+                console.log(a[idx], b[idx]);
+            }
+        });
+        assert(reverted.trim() === rootReverted.trim());
     });
-    assert(reverted.trim() === rootReverted.trim());
-  });
 
-  // https://github.com/aprilandjan/ascii-tree-generator/pull/11
-  test('revert more-depth tree string to text', function () {
-    const origin = fs.readFileSync(path.join(__dirname, '../../fixtures/more-depth-reverted.txt'), 'utf8');
-    const treeString = fs.readFileSync(path.join(__dirname, '../../fixtures/more-depth.txt'), 'utf8');
-    const reverted = revertTreeString(treeString);
-    assert(origin.trim() === reverted.trim());
-  });
+    // https://github.com/aprilandjan/ascii-tree-generator/pull/11
+    test("revert more-depth tree string to text", function () {
+        const origin = fs.readFileSync(
+            path.join(__dirname, "../../fixtures/more-depth-reverted.txt"),
+            "utf8"
+        );
+        const treeString = fs.readFileSync(
+            path.join(__dirname, "../../fixtures/more-depth.txt"),
+            "utf8"
+        );
+        const reverted = revertTreeString(treeString);
+        assert(origin.trim() === reverted.trim());
+    });
 });

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -10,14 +10,14 @@
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
-import * as testRunner from 'vscode/lib/testrunner';
+import * as testRunner from "vscode/lib/testrunner";
 
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
 testRunner.configure({
-    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
-    // ui: 'bdd',  // https://github.com/Microsoft/vscode/issues/5627
-    useColors: true // colored output from test results
+    ui: "tdd", // the TDD UI is being used in extension.test.ts (suite, test, etc.)
+    // ui: 'bdd', // https://github.com/Microsoft/vscode/issues/5627
+    useColors: true, // colored output from test results
 });
 
 module.exports = testRunner;

--- a/src/test/lib/directory.test.ts
+++ b/src/test/lib/directory.test.ts
@@ -1,77 +1,77 @@
-import * as assert from 'assert';
-import * as path from 'path';
+import * as assert from "assert";
+import * as path from "path";
 
-import { listDirectory, formatFileTreeItemsFromDirectory } from '../../lib/directory';
-import { IFileStat } from '../../lib/interface';
+import {
+    listDirectory,
+    formatFileTreeItemsFromDirectory,
+} from "../../lib/directory";
+import { IFileStat } from "../../lib/interface";
 
 function findFileByName(files: IFileStat[] = [], name: string) {
-  let result: IFileStat | undefined = undefined;
-  files.forEach(file => {
-    if (file.name === name) {
-      result = file;
-    } else if (!result) {  
-      result = findFileByName(file.children, name);
-    }
-  });
-  return result;
+    let result: IFileStat | undefined = undefined;
+    files.forEach((file) => {
+        if (file.name === name) {
+            result = file;
+        } else if (!result) {
+            result = findFileByName(file.children, name);
+        }
+    });
+    return result;
 }
 
 suite("lib/directory functions", function () {
-  this.timeout(120000);
+    this.timeout(120000);
 
-  const rootDir: string = path.resolve(__dirname, '../../../fixtures/root');
+    const rootDir: string = path.resolve(__dirname, "../../../fixtures/root");
 
-  test("should correctly list directory", async () => {
-    const files = await listDirectory(rootDir);
-    assert(files.length === 5);
-    const hasChildren = files.filter(file => file.children!.length);
-    assert(hasChildren.length === 0);
-  });
-
-  test('should correctly list directory when ignore', async () => {
-    const ignore = [
-      'node_modules',
-      '.*',
-    ];
-    const files = await listDirectory(rootDir, {
-      ignore,
+    test("should correctly list directory", async () => {
+        const files = await listDirectory(rootDir);
+        assert(files.length === 5);
+        const hasChildren = files.filter((file) => file.children!.length);
+        assert(hasChildren.length === 0);
     });
-    assert(files.length === 3);
-    assert(findFileByName(files, 'node_modules') === undefined);
-    assert(findFileByName(files, '.env') === undefined);
-  });
 
-  test('should correctly list directory when sort', async () => {
-    const files = await listDirectory(rootDir, {
-      sort: true,
+    test("should correctly list directory when ignore", async () => {
+        const ignore = ["node_modules", ".*"];
+        const files = await listDirectory(rootDir, {
+            ignore,
+        });
+        assert(files.length === 3);
+        assert(findFileByName(files, "node_modules") === undefined);
+        assert(findFileByName(files, ".env") === undefined);
     });
-    const fileNames = files.map(item => item.name);
-    assert.deepEqual(fileNames, [
-      'dist',
-      'node_modules',
-      'src',
-      '.env',
-      'README.md',
-    ]);
-  });
 
-  test('should correctly list directories when recursively into depth 3', async () => {
-    const files = await listDirectory(rootDir, {
-      maxDepth: 3,
+    test("should correctly list directory when sort", async () => {
+        const files = await listDirectory(rootDir, {
+            sort: true,
+        });
+        const fileNames = files.map((item) => item.name);
+        assert.deepEqual(fileNames, [
+            "dist",
+            "node_modules",
+            "src",
+            ".env",
+            "README.md",
+        ]);
     });
-    assert(findFileByName(files, 'img'));
-    assert(findFileByName(files, 'logo.png') === undefined);
-  });
 
-  test('should correctly format file tree items', async () => {
-    const fileItems = await formatFileTreeItemsFromDirectory(rootDir, {
-      maxDepth: Number.MAX_VALUE,
-      sort: true,
+    test("should correctly list directories when recursively into depth 3", async () => {
+        const files = await listDirectory(rootDir, {
+            maxDepth: 3,
+        });
+        assert(findFileByName(files, "img"));
+        assert(findFileByName(files, "logo.png") === undefined);
     });
-    assert(fileItems.length === 16);
-    const logo = fileItems.find(item => item.name === 'logo.jpg');
-    assert(logo!.depth === 3);
-    assert(logo!.parent!.depth === 2);
-    assert(logo!.parent!.name === 'img');
-  });
+
+    test("should correctly format file tree items", async () => {
+        const fileItems = await formatFileTreeItemsFromDirectory(rootDir, {
+            maxDepth: Number.MAX_VALUE,
+            sort: true,
+        });
+        assert(fileItems.length === 16);
+        const logo = fileItems.find((item) => item.name === "logo.jpg");
+        assert(logo!.depth === 3);
+        assert(logo!.parent!.depth === 2);
+        assert(logo!.parent!.name === "img");
+    });
 });

--- a/src/test/lib/generator.test.ts
+++ b/src/test/lib/generator.test.ts
@@ -1,57 +1,78 @@
-import * as assert from 'assert';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
 
-import { formatFileTreeItemsFromDirectory } from '../../lib/directory';
-import { formatFileTreeItemsFromText } from '../../lib/text';
-import { generate } from '../../lib/generator';
-import { setTestMode } from '../../utils';
+import { formatFileTreeItemsFromDirectory } from "../../lib/directory";
+import { formatFileTreeItemsFromText } from "../../lib/text";
+import { generate } from "../../lib/generator";
+import { setTestMode } from "../../utils";
 
-suite('lib/generator functions', function () {
-  this.timeout(120000);
-  // Enable test mode to override user defined chars with defaults
-  setTestMode();
-  const rootDir: string = path.resolve(__dirname, '../../../fixtures/root');
-  const rootText = fs.readFileSync(path.join(__dirname, '../../../fixtures/root.txt'), 'utf8');
-  const rootSorted = fs.readFileSync(path.join(__dirname, '../../../fixtures/root-sorted.txt'), 'utf8');
-  const rootFillLeft = fs.readFileSync(path.join(__dirname, '../../../fixtures/root-fill-left.txt'), 'utf8');
+suite("lib/generator functions", function () {
+    this.timeout(120000);
+    // Enable test mode to override user defined chars with defaults
+    setTestMode();
+    const rootDir: string = path.resolve(__dirname, "../../../fixtures/root");
+    const rootText = fs.readFileSync(
+        path.join(__dirname, "../../../fixtures/root.txt"),
+        "utf8"
+    );
+    const rootSorted = fs.readFileSync(
+        path.join(__dirname, "../../../fixtures/root-sorted.txt"),
+        "utf8"
+    );
+    const rootFillLeft = fs.readFileSync(
+        path.join(__dirname, "../../../fixtures/root-fill-left.txt"),
+        "utf8"
+    );
 
-  test('should correctly generate tree from directory', async () => {
-    const items = await formatFileTreeItemsFromDirectory(rootDir, {
-      maxDepth: Number.MAX_VALUE,
-      sort: true,
+    test("should correctly generate tree from directory", async () => {
+        const items = await formatFileTreeItemsFromDirectory(rootDir, {
+            maxDepth: Number.MAX_VALUE,
+            sort: true,
+        });
+        const treeText = generate(items);
+        assert(treeText.trim() === rootSorted.trim());
     });
-    const treeText = generate(items);
-    assert(treeText.trim() === rootSorted.trim());
-  });
 
-  test('should correctly generate tree from hash text', () => {
-    const text = fs.readFileSync(path.join(__dirname, '../../../fixtures/hash.txt'), 'utf8');
-    const items = formatFileTreeItemsFromText(text);
-    const treeText = generate(items);
-    assert(treeText.trim() === rootText.trim());
-  });
-
-  test('should correctly generate tree from indent text', () => {
-    const text = fs.readFileSync(path.join(__dirname, '../../../fixtures/indent.txt'), 'utf8');
-    const items = formatFileTreeItemsFromText(text);
-    const treeText = generate(items);
-    assert(treeText.trim() === rootText.trim());
-  });
-
-  test('should correctly generate tree from hash-indented text if fill-left', () => {
-    const text = fs.readFileSync(path.join(__dirname, '../../../fixtures/hash-indented.txt'), 'utf8');
-    const items = formatFileTreeItemsFromText(text);
-    const treeText = generate(items);
-    assert(treeText === rootFillLeft);
-  });
-
-  test('should correctly generate tree from hash-indented text if not fill-left', () => {
-    const text = fs.readFileSync(path.join(__dirname, '../../../fixtures/hash-indented.txt'), 'utf8');
-    const items = formatFileTreeItemsFromText(text);
-    const treeText = generate(items, {
-      fillLeft: false,
+    test("should correctly generate tree from hash text", () => {
+        const text = fs.readFileSync(
+            path.join(__dirname, "../../../fixtures/hash.txt"),
+            "utf8"
+        );
+        const items = formatFileTreeItemsFromText(text);
+        const treeText = generate(items);
+        assert(treeText.trim() === rootText.trim());
     });
-    assert(treeText === rootText);
-  });
+
+    test("should correctly generate tree from indent text", () => {
+        const text = fs.readFileSync(
+            path.join(__dirname, "../../../fixtures/indent.txt"),
+            "utf8"
+        );
+        const items = formatFileTreeItemsFromText(text);
+        const treeText = generate(items);
+        assert(treeText.trim() === rootText.trim());
+    });
+
+    test("should correctly generate tree from hash-indented text if fill-left", () => {
+        const text = fs.readFileSync(
+            path.join(__dirname, "../../../fixtures/hash-indented.txt"),
+            "utf8"
+        );
+        const items = formatFileTreeItemsFromText(text);
+        const treeText = generate(items);
+        assert(treeText === rootFillLeft);
+    });
+
+    test("should correctly generate tree from hash-indented text if not fill-left", () => {
+        const text = fs.readFileSync(
+            path.join(__dirname, "../../../fixtures/hash-indented.txt"),
+            "utf8"
+        );
+        const items = formatFileTreeItemsFromText(text);
+        const treeText = generate(items, {
+            fillLeft: false,
+        });
+        assert(treeText === rootText);
+    });
 });

--- a/src/test/lib/text.test.ts
+++ b/src/test/lib/text.test.ts
@@ -1,123 +1,138 @@
-import * as assert from 'assert';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
 
-import { formatFileTreeItemsFromText } from '../../lib/text';
-import { IFileTreeItem } from '../../lib/interface';
+import { formatFileTreeItemsFromText } from "../../lib/text";
+import { IFileTreeItem } from "../../lib/interface";
 
-function findTreeItem (list: IFileTreeItem[] , name: string) {
-  return list.find(item => item.name === name);
+function findTreeItem(list: IFileTreeItem[], name: string) {
+    return list.find((item) => item.name === name);
 }
 
-suite('lib/text functions', function () {
-  this.timeout(120000);
+suite("lib/text functions", function () {
+    this.timeout(120000);
 
-  suite('parse from hash text', () => {
-    let items: IFileTreeItem[];
-    setup(function() {
-      const text = fs.readFileSync(path.join(__dirname, '../../../fixtures/hash.txt'), 'utf8');
-      items = formatFileTreeItemsFromText(text);
+    suite("parse from hash text", () => {
+        let items: IFileTreeItem[];
+        setup(function () {
+            const text = fs.readFileSync(
+                path.join(__dirname, "../../../fixtures/hash.txt"),
+                "utf8"
+            );
+            items = formatFileTreeItemsFromText(text);
+        });
+
+        test("should correctly format no-parent non-last file", () => {
+            const dist = findTreeItem(items, "dist");
+            assert(dist && dist.isLast === false && !dist.parent);
+        });
+
+        test("should correctly format no-parent last file", () => {
+            const src = findTreeItem(items, "src");
+            assert(src && src.isLast === true && !src.parent);
+        });
+
+        test("should correctly format has-parent non-last file", () => {
+            const dist = findTreeItem(items, "dist");
+            const assets = findTreeItem(items, "assets");
+            assert(assets && assets.isLast === false && assets.parent === dist);
+        });
+
+        test("should correctly format has-parent last file", () => {
+            const logo = findTreeItem(items, "logo.jpg");
+            assert(logo && logo.isLast === true && logo.parent);
+        });
     });
 
-    test('should correctly format no-parent non-last file', () => {
-      const dist = findTreeItem(items, 'dist');
-      assert(dist && dist.isLast === false && !dist.parent);
+    suite("parse from indent text", () => {
+        let items: IFileTreeItem[];
+        setup(() => {
+            const text = fs.readFileSync(
+                path.join(__dirname, "../../../fixtures/indent.txt"),
+                "utf8"
+            );
+            items = formatFileTreeItemsFromText(text);
+        });
+
+        test("should correctly format no-parent non-last file", () => {
+            const dist = findTreeItem(items, "dist");
+            assert(dist && dist.isLast === false && !dist.parent);
+        });
+
+        test("should correctly format no-parent last file", () => {
+            const src = findTreeItem(items, "src");
+            assert(src && src.isLast === true && !src.parent);
+        });
+
+        test("should correctly format has-parent non-last file", () => {
+            const dist = findTreeItem(items, "dist");
+            const assets = findTreeItem(items, "assets");
+            assert(assets && assets.isLast === false && assets.parent === dist);
+        });
+
+        test("should correctly format has-parent last file", () => {
+            const logo = findTreeItem(items, "logo.jpg");
+            assert(logo && logo.isLast === true && logo.parent);
+        });
     });
 
-    test('should correctly format no-parent last file', () => {
-      const src = findTreeItem(items, 'src');
-      assert(src && src.isLast === true && !src.parent);
+    suite("parse from hash-indented text", () => {
+        let items: IFileTreeItem[];
+        setup(() => {
+            const text = fs.readFileSync(
+                path.join(__dirname, "../../../fixtures/hash-indented.txt"),
+                "utf8"
+            );
+            items = formatFileTreeItemsFromText(text);
+        });
+
+        test("should correctly format item names", () => {
+            const first = items[0];
+            const env = findTreeItem(items, ".env");
+            assert(first === env);
+        });
+
+        test("should correctly format no-parent non-last file", () => {
+            const dist = findTreeItem(items, "dist");
+            assert(dist && dist.isLast === false && !dist.parent);
+        });
+
+        test("should correctly format no-parent last file", () => {
+            const src = findTreeItem(items, "src");
+            assert(src && src.isLast === true && !src.parent);
+        });
+
+        test("should correctly format has-parent non-last file", () => {
+            const dist = findTreeItem(items, "dist");
+            const assets = findTreeItem(items, "assets");
+            assert(assets && assets.isLast === false && assets.parent === dist);
+        });
+
+        test("should correctly format has-parent last file", () => {
+            const logo = findTreeItem(items, "logo.jpg");
+            assert(logo && logo.isLast === true && logo.parent);
+        });
     });
 
-    test('should correctly format has-parent non-last file', () => {
-      const dist = findTreeItem(items, 'dist');
-      const assets = findTreeItem(items, 'assets');
-      assert(assets && assets.isLast === false && assets.parent === dist);
-    });
+    suite("parse from hash-common-beginning text", () => {
+        let items: IFileTreeItem[];
+        setup(() => {
+            const text = fs.readFileSync(
+                path.join(
+                    __dirname,
+                    "../../../fixtures/hash-common-beginning.txt"
+                ),
+                "utf8"
+            );
+            items = formatFileTreeItemsFromText(text);
+        });
 
-    test('should correctly format has-parent last file', () => {
-      const logo = findTreeItem(items, 'logo.jpg');
-      assert(logo && logo.isLast === true && logo.parent);
+        test("should correctly format last file", () => {
+            const first = items[0];
+            const last = items[items.length - 1];
+            assert(first.isLast === false);
+            assert(last.isLast === true);
+            assert(first.depth === last.depth);
+        });
     });
-  });
-
-  suite('parse from indent text', () => {
-    let items: IFileTreeItem[];
-    setup(() => {
-      const text = fs.readFileSync(path.join(__dirname, '../../../fixtures/indent.txt'), 'utf8');
-      items = formatFileTreeItemsFromText(text);
-    });
-
-    test('should correctly format no-parent non-last file', () => {
-      const dist = findTreeItem(items, 'dist');
-      assert(dist && dist.isLast === false && !dist.parent);
-    });
-
-    test('should correctly format no-parent last file', () => {
-      const src = findTreeItem(items, 'src');
-      assert(src && src.isLast === true && !src.parent);
-    });
-
-    test('should correctly format has-parent non-last file', () => {
-      const dist = findTreeItem(items, 'dist');
-      const assets = findTreeItem(items, 'assets');
-      assert(assets && assets.isLast === false && assets.parent === dist);
-    });
-
-    test('should correctly format has-parent last file', () => {
-      const logo = findTreeItem(items, 'logo.jpg');
-      assert(logo && logo.isLast === true && logo.parent);
-    });
-  });
-
-  suite('parse from hash-indented text', () => {
-    let items: IFileTreeItem[];
-    setup(() => {
-      const text = fs.readFileSync(path.join(__dirname, '../../../fixtures/hash-indented.txt'), 'utf8');
-      items = formatFileTreeItemsFromText(text);
-    });
-
-    test('should correctly format item names', () => {
-      const first = items[0];
-      const env = findTreeItem(items, '.env');
-      assert(first === env);
-    });
-
-    test('should correctly format no-parent non-last file', () => {
-      const dist = findTreeItem(items, 'dist');
-      assert(dist && dist.isLast === false && !dist.parent);
-    });
-
-    test('should correctly format no-parent last file', () => {
-      const src = findTreeItem(items, 'src');
-      assert(src && src.isLast === true && !src.parent);
-    });
-
-    test('should correctly format has-parent non-last file', () => {
-      const dist = findTreeItem(items, 'dist');
-      const assets = findTreeItem(items, 'assets');
-      assert(assets && assets.isLast === false && assets.parent === dist);
-    });
-
-    test('should correctly format has-parent last file', () => {
-      const logo = findTreeItem(items, 'logo.jpg');
-      assert(logo && logo.isLast === true && logo.parent);
-    });
-  });
-
-  suite('parse from hash-common-beginning text', () => {
-    let items: IFileTreeItem[];
-    setup(() => {
-      const text = fs.readFileSync(path.join(__dirname, '../../../fixtures/hash-common-beginning.txt'), 'utf8');
-      items = formatFileTreeItemsFromText(text);
-    });
-
-    test('should correctly format last file', () => {
-      const first = items[0];
-      const last = items[items.length - 1];
-      assert(first.isLast === false);
-      assert(last.isLast === true);
-      assert(first.depth === last.depth);
-    });
-  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,8 +29,8 @@ export function getUserEOL() {
  */
 export function createWebview(context: vscode.ExtensionContext, text = "") {
     const panel = vscode.window.createWebviewPanel(
-        "AsciiTreeGenerator",
-        "Ascii Tree",
+        "ASCII Tree Generator",
+        "ASCII Tree",
         vscode.ViewColumn.One,
         {
             enableScripts: true,
@@ -53,7 +53,7 @@ export function createWebview(context: vscode.ExtensionContext, text = "") {
                 case "copy":
                     vscode.env.clipboard.writeText(text).then(() => {
                         vscode.window.showInformationMessage(
-                            "Copy to Clipboard Successfully."
+                            "Copied to clipboard successfully!"
                         );
                     });
                     break;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,9 @@
-import * as vscode from 'vscode';
-import * as fs from 'fs';
-import * as path from 'path';
-import { defaultCharset } from './lib/generator';
-import { ICharset, IVsCodeConfig } from './lib/interface';
-import { getConfig } from './config';
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import { defaultCharset } from "./lib/generator";
+import { ICharset, IVsCodeConfig } from "./lib/interface";
+import { getConfig } from "./config";
 
 let isInTestMode: boolean = false;
 
@@ -11,12 +11,15 @@ let isInTestMode: boolean = false;
  * get user file eol setting. if not specific, behave defaultly according platform
  */
 export function getUserEOL() {
-  //  strange type definition of 'get'...
-  const eol = vscode.workspace.getConfiguration('files').get('eol') as 'auto' | '\n' | '\r\n';
-  if (!eol || eol === 'auto') {
-    return process.platform === "win32" ? '\r\n' : '\n';
-  }
-  return eol;
+    //  strange type definition of 'get'...
+    const eol = vscode.workspace.getConfiguration("files").get("eol") as
+        | "auto"
+        | "\n"
+        | "\r\n";
+    if (!eol || eol === "auto") {
+        return process.platform === "win32" ? "\r\n" : "\n";
+    }
+    return eol;
 }
 
 /**
@@ -24,80 +27,104 @@ export function getUserEOL() {
  * @param text
  * @param context
  */
-export function createWebview(context: vscode.ExtensionContext, text = '') {
-  const panel = vscode.window.createWebviewPanel(
-    'AsciiTreeGenerator',
-    'Ascii Tree',
-    vscode.ViewColumn.One,
-    {
-      enableScripts: true,
-    }
-  );
+export function createWebview(context: vscode.ExtensionContext, text = "") {
+    const panel = vscode.window.createWebviewPanel(
+        "AsciiTreeGenerator",
+        "Ascii Tree",
+        vscode.ViewColumn.One,
+        {
+            enableScripts: true,
+        }
+    );
 
-  panel.webview.html = fs.readFileSync(path.join(__dirname, '../static/webview.html'), 'utf8');
-  panel.webview.postMessage({
-    command: 'setText',
-    payload: text,
-  });
-  //	listen webview messages
-  panel.webview.onDidReceiveMessage(message => {
-    const { command } = message;
-    switch (command) {
-      case 'copy':
-        vscode.env.clipboard.writeText(text).then(() => {
-          vscode.window.showInformationMessage('Copy to Clipboard Successfully.');
-        });
-        break;
-    }
-  }, null, context.subscriptions);
-
-  panel.onDidChangeViewState(e => {
-    const panel = e.webviewPanel;
-    if (panel.active) {
-      panel.webview.postMessage({
-        command: 'setText',
+    panel.webview.html = fs.readFileSync(
+        path.join(__dirname, "../static/webview.html"),
+        "utf8"
+    );
+    panel.webview.postMessage({
+        command: "setText",
         payload: text,
-      });
-    }
-  }, null, context.subscriptions);
+    });
+    //	listen webview messages
+    panel.webview.onDidReceiveMessage(
+        (message) => {
+            const { command } = message;
+            switch (command) {
+                case "copy":
+                    vscode.env.clipboard.writeText(text).then(() => {
+                        vscode.window.showInformationMessage(
+                            "Copy to Clipboard Successfully."
+                        );
+                    });
+                    break;
+            }
+        },
+        null,
+        context.subscriptions
+    );
 
-  return panel;
+    panel.onDidChangeViewState(
+        (e) => {
+            const panel = e.webviewPanel;
+            if (panel.active) {
+                panel.webview.postMessage({
+                    command: "setText",
+                    payload: text,
+                });
+            }
+        },
+        null,
+        context.subscriptions
+    );
+
+    return panel;
 }
 
 /** create a revert regexp according to current config, and revert tree-string back */
-export function revertTreeString(treeString: string, replaceWith = '#') {
-  const { child, last, parent, dash, blank } = getCharCodesFromConfig();
-  //  [└├]──|│ {3}|^( {4})+?|( {4})(?=.*[└├│])
-  const reg = new RegExp(`[${last}${child}]${dash}${dash}|${parent}${blank}{3}|^(${blank}{4})+?|(${blank}{4})(?=.*[${last}${child}${parent}])`, 'gm');
-  return treeString.replace(reg, replaceWith);
+export function revertTreeString(treeString: string, replaceWith = "#") {
+    const { child, last, parent, dash, blank } = getCharCodesFromConfig();
+    //  [└├]──|│ {3}|^( {4})+?|( {4})(?=.*[└├│])
+    const reg = new RegExp(
+        `[${last}${child}]${dash}${dash}|${parent}${blank}{3}|^(${blank}{4})+?|(${blank}{4})(?=.*[${last}${child}${parent}])`,
+        "gm"
+    );
+    return treeString.replace(reg, replaceWith);
 }
 
 export function setTestMode() {
-  console.info("Test mode was enabled: The default charset will be used instead of the user-defined");
-  isInTestMode = true;
+    console.info(
+        "Test mode was enabled: The default charset will be used instead of the user-defined"
+    );
+    isInTestMode = true;
 }
 
 export function getCharCodesFromConfig(): ICharset {
-  if (isInTestMode) {
-    return defaultCharset;
-  }
-  let config: IVsCodeConfig = getConfig();
-  let charset: ICharset = {
-    root: validateCharCode(config.rootCharCode, defaultCharset.root),
-    child: validateCharCode(config.childCharCode, defaultCharset.child),
-    last: validateCharCode(config.lastCharCode, defaultCharset.last),
-    parent: validateCharCode(config.parentCharCode, defaultCharset.parent),
-    dash: validateCharCode(config.dashCharCode, defaultCharset.dash),
-    blank: validateCharCode(config.blankCharCode, defaultCharset.blank)
-  };
-  return charset;
+    if (isInTestMode) {
+        return defaultCharset;
+    }
+    let config: IVsCodeConfig = getConfig();
+    let charset: ICharset = {
+        root: validateCharCode(config.rootCharCode, defaultCharset.root),
+        child: validateCharCode(config.childCharCode, defaultCharset.child),
+        last: validateCharCode(config.lastCharCode, defaultCharset.last),
+        parent: validateCharCode(config.parentCharCode, defaultCharset.parent),
+        dash: validateCharCode(config.dashCharCode, defaultCharset.dash),
+        blank: validateCharCode(config.blankCharCode, defaultCharset.blank),
+    };
+    return charset;
 }
 
-function validateCharCode(userValue: number | undefined, fallback: string): string {
-  if (typeof userValue === "undefined" || userValue < 0 || userValue > 65535) {
-    return fallback;
-  }
-  else {
-    return String.fromCharCode(userValue);
-  }
+function validateCharCode(
+    userValue: number | undefined,
+    fallback: string
+): string {
+    if (
+        typeof userValue === "undefined" ||
+        userValue < 0 ||
+        userValue > 65535
+    ) {
+        return fallback;
+    } else {
+        return String.fromCharCode(userValue);
+    }
 }

--- a/static/webview.html
+++ b/static/webview.html
@@ -1,110 +1,122 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Tree</title>
-  <style>
-    html, body {
-      background-color: rgba(0, 0, 0, 0.05);
-      background-color: rgba(0, 0, 0, 0.05);
-      height: 100%;
-      margin: 0;
-    }
-    #app {
-      padding-top: 30px;
-      margin: 0 8px;
-    }
-    #actions {
-      position: fixed;
-      right: 0;
-      top: 0;
-      height: 48px;
-      padding: 0 8px;
-      line-height: 48px;
-      left: 0;
-      text-align: right;
-      background-color: rgba(0, 0, 0, 0.05);
-    }
-    #content {
-    }
-    button {
-      cursor: pointer;
-      border: 1px solid rgba(0,0,0,.12);
-      padding: 0 15px;
-      box-sizing: border-box;
-      position: relative;
-      -webkit-user-select: none;
-      -moz-user-select: none;
-      -ms-user-select: none;
-      user-select: none;
-      cursor: pointer;
-      outline: 0;
-      /* border: none; */
-      -webkit-tap-highlight-color: transparent;
-      display: inline-block;
-      white-space: nowrap;
-      text-decoration: none;
-      vertical-align: baseline;
-      text-align: center;
-      margin: 0;
-      min-width: 64px;
-      line-height: 30px;
-      padding: 0 16px;
-      border-radius: 4px;
-      overflow: visible;
-      font-size: 12px;
-      font-weight: 500;
-      box-shadow: 0 3px 1px -2px rgba(0,0,0,.2), 0 2px 2px 0 rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12);
-      background-color: white;
-      transition: background-color 0.2s;
-    }
-    button:hover {
-      background-color: rgb(232, 232, 232);
-    }
-  </style>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Tree</title>
+    <style>
+        html,
+        body {
+            background-color: rgba(0, 0, 0, 0.05);
+            background-color: rgba(0, 0, 0, 0.05);
+            height: 100%;
+            margin: 0;
+        }
+
+        #app {
+            padding-top: 30px;
+            margin: 0 8px;
+        }
+
+        #actions {
+            position: fixed;
+            right: 0;
+            top: 0;
+            height: 48px;
+            padding: 0 8px;
+            line-height: 48px;
+            left: 0;
+            text-align: right;
+            background-color: rgba(0, 0, 0, 0.05);
+        }
+
+        #content {}
+
+        button {
+            cursor: pointer;
+            border: 1px solid rgba(0, 0, 0, .12);
+            padding: 0 15px;
+            box-sizing: border-box;
+            position: relative;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+            cursor: pointer;
+            outline: 0;
+            /* border: none; */
+            -webkit-tap-highlight-color: transparent;
+            display: inline-block;
+            white-space: nowrap;
+            text-decoration: none;
+            vertical-align: baseline;
+            text-align: center;
+            margin: 0;
+            min-width: 64px;
+            line-height: 30px;
+            padding: 0 16px;
+            border-radius: 4px;
+            overflow: visible;
+            font-size: 12px;
+            font-weight: 500;
+            box-shadow: 0 3px 1px -2px rgba(0, 0, 0, .2), 0 2px 2px 0 rgba(0, 0, 0, .14), 0 1px 5px 0 rgba(0, 0, 0, .12);
+            background-color: white;
+            transition: background-color 0.2s;
+        }
+
+        button:hover {
+            background-color: rgb(232, 232, 232);
+        }
+    </style>
 </head>
+
 <body>
-  <div id="app">
-    <div id="actions">
-      <button id="btnCopy">Copy To Clipboard</button>
-    </div>
-    <div id="content">
-      <pre id="text">
+    <div id="app">
+        <div id="actions">
+            <button id="btnCopy">Copy To Clipboard</button>
+        </div>
+        <div id="content">
+            <pre id="text">
       </pre>
+        </div>
     </div>
-  </div>
-  <script>
-    function showApp(visible) {
-      document.querySelector('#app').hidden = !visible;
-    }
-    function setText(text) {
-      document.querySelector('#text').innerText = text;
-    }
-    if (acquireVsCodeApi) {
-      setText('');
-      (() => {
-        //  this vscode object cannot be exposed in global context
-        const vscode = acquireVsCodeApi();
+    <script>
+        function showApp(visible) {
+            document.querySelector('#app').hidden = !visible;
+        }
 
-        // Handle the message inside the webview
-        window.addEventListener('message', event => {
-          const { command, payload } = event.data;
-          switch (command) {
-            case 'setText':
-              setText(payload);
-              break;
-          }
-        });
+        function setText(text) {
+            document.querySelector('#text').innerText = text;
+        }
+        if (acquireVsCodeApi) {
+            setText('');
+            (() => {
+                //  this vscode object cannot be exposed in global context
+                const vscode = acquireVsCodeApi();
 
-        document.querySelector('#btnCopy').addEventListener('click', () => {
-          vscode.postMessage({
-            command: 'copy',
-          });
-        });
-      })();
-    }
-  </script>
+                // Handle the message inside the webview
+                window.addEventListener('message', event => {
+                    const {
+                        command,
+                        payload
+                    } = event.data;
+                    switch (command) {
+                        case 'setText':
+                            setText(payload);
+                            break;
+                    }
+                });
+
+                document.querySelector('#btnCopy').addEventListener('click', () => {
+                    vscode.postMessage({
+                        command: 'copy',
+                    });
+                });
+            })();
+        }
+    </script>
 </body>
+
 </html>


### PR DESCRIPTION
Generally, I have found that most other extensions used the `.` syntax for the properties their extension uses in `settings.json`. Therefore, in this pull request, I have reformatted the property names.

I also performed some general changes outlined below:

- Reordered property names in an order that made sense to me
- Reordered property name references elsewhere for consistency
- Formalized language use inside `README.md`